### PR TITLE
Cookie auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ deployments/chart/stella/requirements.lock
 
 # sqlite files
 *.db
+
+/values.dev.yaml

--- a/authsvc/cmd/webauthsvc/main.go
+++ b/authsvc/cmd/webauthsvc/main.go
@@ -56,6 +56,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/auth/", http.StripPrefix("/auth", websrv))
 	mux.HandleFunc("/health", health)
+	mux.HandleFunc("/", health)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)

--- a/authsvc/internal/app/authsrv/server_test.go
+++ b/authsvc/internal/app/authsrv/server_test.go
@@ -1,0 +1,79 @@
+package authsrv_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Buzzvil/stella/authsvc/internal/pkg/auth/jwt"
+
+	"github.com/Buzzvil/stella/authsvc/internal/app/authsrv"
+	"github.com/Buzzvil/stella/authsvc/internal/pkg/auth"
+
+	ev "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type mockUsecase struct {
+	mock.Mock
+}
+
+func (u *mockUsecase) GetUserByID(id int) (*auth.User, error) {
+	args := u.Called(id)
+	return args.Get(0).(*auth.User), args.Error(1)
+}
+
+func (u *mockUsecase) FindOrCreateUserFromSlack(t *oauth2.Token) (*auth.User, error) {
+	args := u.Called(t)
+	return args.Get(0).(*auth.User), args.Error(1)
+}
+
+func TestServerCheck(t *testing.T) {
+	signingKey := []byte("key")
+	u := new(mockUsecase)
+	c := authsrv.Config{JWTSigningKey: signingKey, Usecase: u}
+	s := authsrv.New(c)
+	user := auth.User{ID: 1001}
+
+	u.On("GetUserByID", user.ID).Return(&user).Once()
+
+	t.Run("ValidToken", func(t *testing.T) {
+		ts, err := jwt.SignedUserToken(signingKey, user.ID)
+		require.Nil(t, err)
+		req := ev.CheckRequest{
+			Attributes: &ev.AttributeContext{
+				Request: &ev.AttributeContext_Request{
+					Http: &ev.AttributeContext_HttpRequest{
+						Headers: map[string]string{"cookie": fmt.Sprintf("auth-token=%s", ts)},
+					},
+				},
+			},
+		}
+
+		res, err := s.Check(context.Background(), &req)
+		require.Nil(t, err)
+		require.NotNil(t, res)
+		assert.NotNil(t, res.GetOkResponse())
+	})
+
+	t.Run("InvalidToken", func(t *testing.T) {
+		ts := "invalid token"
+		req := ev.CheckRequest{
+			Attributes: &ev.AttributeContext{
+				Request: &ev.AttributeContext_Request{
+					Http: &ev.AttributeContext_HttpRequest{
+						Headers: map[string]string{"cookie": fmt.Sprintf("auth-token=%s", ts)},
+					},
+				},
+			},
+		}
+
+		res, err := s.Check(context.Background(), &req)
+		require.Nil(t, err)
+		require.NotNil(t, res)
+		assert.NotNil(t, res.GetDeniedResponse().GetBody())
+	})
+}

--- a/authsvc/internal/app/webauthsrv/handlers.go
+++ b/authsvc/internal/app/webauthsrv/handlers.go
@@ -37,14 +37,19 @@ func exchangeTokenFromCode(c *oauth2.Config, code string) (*oauth2.Token, error)
 	return token, nil
 }
 
-func (s *server) oauthSlackLogin(w http.ResponseWriter, r *http.Request) {
+func (s *server) OauthSlackLogin(w http.ResponseWriter, r *http.Request) {
 	oauthState := generateStateOauthCookie(w)
 	u := s.slackOauthConfig.AuthCodeURL(oauthState)
 	http.Redirect(w, r, u, http.StatusTemporaryRedirect)
 }
 
-func (s *server) oauthSlackCallback(w http.ResponseWriter, r *http.Request) {
-	oauthState, _ := r.Cookie(oauthstateCookie)
+func (s *server) OauthSlackCallback(w http.ResponseWriter, r *http.Request) {
+	oauthState, err := r.Cookie(oauthstateCookie)
+	if err != nil {
+		log.Printf("oauth state parse error: %s\n", err)
+		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		return
+	}
 
 	if r.FormValue("state") != oauthState.Value {
 		log.Println("invalid oauth state")

--- a/authsvc/internal/app/webauthsrv/handlers_test.go
+++ b/authsvc/internal/app/webauthsrv/handlers_test.go
@@ -68,7 +68,7 @@ func (s *handlerTestSuite) TestOauthSlackCallback() {
 	c := webauthsrv.Config{WebHost: s.webHost, JWTSigningKey: s.signingKey, Usecase: s.usecase, SlackOauthConfig: s.slackOauthConfig}
 	srv := webauthsrv.New(c)
 
-	t.Run("InvalidOauthState", func(t *testing.T) {
+	t.Run("NoOauthState", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/slack/callback", nil)
 		require.Nil(err)
 
@@ -78,7 +78,6 @@ func (s *handlerTestSuite) TestOauthSlackCallback() {
 		assert.Equal(http.StatusTemporaryRedirect, rr.Code)
 		assert.Zero(req.Cookie("auth-token"))
 	})
-
 }
 
 func TestHandlerTestSuite(t *testing.T) {

--- a/authsvc/internal/app/webauthsrv/handlers_test.go
+++ b/authsvc/internal/app/webauthsrv/handlers_test.go
@@ -1,0 +1,86 @@
+package webauthsrv_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Buzzvil/stella/authsvc/internal/pkg/auth"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/slack"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Buzzvil/stella/authsvc/internal/app/webauthsrv"
+
+	"github.com/stretchr/testify/require"
+)
+
+type handlerTestSuite struct {
+	suite.Suite
+	signingKey       []byte
+	usecase          auth.Usecase
+	webHost          string
+	slackOauthConfig *oauth2.Config
+}
+
+func (s *handlerTestSuite) SetupSuite() {
+	s.usecase = new(mockUsecase)
+	s.signingKey = []byte("key")
+	s.webHost = "https://example.com"
+	oc := &oauth2.Config{
+		RedirectURL:  fmt.Sprintf("%s/auth/slack/callback", s.webHost),
+		ClientID:     "clientid",
+		ClientSecret: "clientsecret",
+		Scopes:       []string{"identity.basic", "identity.avatar"},
+		Endpoint:     slack.Endpoint,
+	}
+	s.slackOauthConfig = oc
+}
+
+func (s *handlerTestSuite) TestOauthSlackLogin() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+
+	c := webauthsrv.Config{WebHost: s.webHost, JWTSigningKey: s.signingKey, Usecase: s.usecase, SlackOauthConfig: s.slackOauthConfig}
+	srv := webauthsrv.New(c)
+
+	req, err := http.NewRequest("GET", "/slack/login", nil)
+	require.Nil(err)
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	req = &http.Request{Header: http.Header{"Cookie": rr.HeaderMap["Set-Cookie"]}}
+
+	assert.Equal(http.StatusTemporaryRedirect, rr.Code)
+	assert.Contains(rr.Header().Get("Location"), slack.Endpoint.AuthURL)
+	assert.NotZero(req.Cookie("oauthstate"))
+}
+
+func (s *handlerTestSuite) TestOauthSlackCallback() {
+	t := s.T()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	c := webauthsrv.Config{WebHost: s.webHost, JWTSigningKey: s.signingKey, Usecase: s.usecase, SlackOauthConfig: s.slackOauthConfig}
+	srv := webauthsrv.New(c)
+
+	t.Run("InvalidOauthState", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/slack/callback", nil)
+		require.Nil(err)
+
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		assert.Equal(http.StatusTemporaryRedirect, rr.Code)
+		assert.Zero(req.Cookie("auth-token"))
+	})
+
+}
+
+func TestHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(handlerTestSuite))
+}

--- a/authsvc/internal/app/webauthsrv/server.go
+++ b/authsvc/internal/app/webauthsrv/server.go
@@ -40,8 +40,8 @@ func New(c Config) http.Handler {
 		c.SlackOauthConfig,
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/slack/login", s.oauthSlackLogin)
-	mux.HandleFunc("/slack/callback", s.oauthSlackCallback)
+	mux.HandleFunc("/slack/login", s.OauthSlackLogin)
+	mux.HandleFunc("/slack/callback", s.OauthSlackCallback)
 	// mux.HandleFunc("/user", s.userProfile)
 	return mux
 }

--- a/authsvc/internal/app/webauthsrv/server_test.go
+++ b/authsvc/internal/app/webauthsrv/server_test.go
@@ -1,0 +1,22 @@
+package webauthsrv_test
+
+import (
+	"github.com/Buzzvil/stella/authsvc/internal/pkg/auth"
+	"golang.org/x/oauth2"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockUsecase struct {
+	mock.Mock
+}
+
+func (u *mockUsecase) GetUserByID(id int) (*auth.User, error) {
+	args := u.Called(id)
+	return args.Get(0).(*auth.User), args.Error(1)
+}
+
+func (u *mockUsecase) FindOrCreateUserFromSlack(t *oauth2.Token) (*auth.User, error) {
+	args := u.Called(t)
+	return args.Get(0).(*auth.User), args.Error(1)
+}

--- a/authsvc/internal/pkg/auth/jwt/jwt.go
+++ b/authsvc/internal/pkg/auth/jwt/jwt.go
@@ -8,6 +8,10 @@ import (
 	jwtlib "github.com/dgrijalva/jwt-go"
 )
 
+// TokenLifetime is duration a token is valid.
+const TokenLifetime = time.Hour * 24 * 2
+const issuer = "authsvc"
+
 // AuthClaims consists of standard jwt claims and UserID.
 type AuthClaims struct {
 	UserID int `json:"user_id"`
@@ -19,8 +23,8 @@ func SignedUserToken(signingKey []byte, userID int) (string, error) {
 	claims := AuthClaims{
 		userID,
 		jwtlib.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Hour * 24).Unix(),
-			Issuer:    "authsvc",
+			ExpiresAt: time.Now().Add(TokenLifetime).Unix(),
+			Issuer:    issuer,
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/booksvc/cmd/booksvc/main.go
+++ b/booksvc/cmd/booksvc/main.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log"
 	"net"
+	"os"
 
 	"github.com/Buzzvil/stella/booksvc/internal/app/booksrv"
 	pb "github.com/Buzzvil/stella/booksvc/pkg/proto"
@@ -19,7 +20,7 @@ func main() {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}
 
-	db, err := sql.Open("postgres", "")
+	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
 	if err != nil {
 		log.Fatalf("Failed to open database: %v", err)
 	}

--- a/booksvc/internal/pkg/book/bookrepo/repo.go
+++ b/booksvc/internal/pkg/book/bookrepo/repo.go
@@ -51,7 +51,21 @@ func (r *repo) GetByISBN(isbn string) (*book.Book, error) {
 }
 
 func (r *repo) GetByFilter(filter string) ([]book.Book, error) {
-	return nil, nil
+	books := []book.Book{}
+	rows, err := r.db.Query("SELECT id, name, isbn, publisher, content FROM books WHERE name LIKE '%' || $1 || '%'", filter)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		b := book.Book{}
+		if err := rows.Scan(&b.ID, &b.Name, &b.Isbn, &b.Publisher, &b.Content); err != nil {
+			return nil, err
+		}
+		books = append(books, b)
+	}
+
+	return books, nil
 }
 
 func (r *repo) Create(book book.Book) (*book.Book, error) {

--- a/deployments/chart/stella/charts/authsvc/templates/web-deployment.yaml
+++ b/deployments/chart/stella/charts/authsvc/templates/web-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: SLACK_OAUTH_CLIENT_ID
               value: {{ .Values.env.SLACK_OAUTH_CLIENT_ID | quote }}
             - name: SLACK_OAUTH_CLIENT_SECRET
-              value: {{ .Values.env.SLACK_OAUTH_CLIENT_CLIENT | quote }}
+              value: {{ .Values.env.SLACK_OAUTH_CLIENT_SECRET | quote }}
             - name: WEB_HOST
               value: {{ .Values.global.webHost }}
           resources:

--- a/deployments/chart/stella/charts/booksvc/templates/deployment.yaml
+++ b/deployments/chart/stella/charts/booksvc/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 9000
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.env.DATABASE_URL }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/frontend/src/hooks/BookLister/BookLister.tsx
+++ b/frontend/src/hooks/BookLister/BookLister.tsx
@@ -5,11 +5,11 @@ import Loader from "../Loader/Loader";
 
 const bookService = new BookServiceClient(process.env.PUBLIC_URL, null, null);
 
-export default (query: any): [boolean, Book[]] => {
+export default (query: string): [boolean, Book[]] => {
   const [loading, load] = Loader();
   const [books, setBooks] = useState<Book[]>([]);
   // Fetch Books
-  const listBooks = (q: any) => () => {
+  const listBooks = (q: string) => () => {
       const req = new ListBooksRequest();
       req.setFilter(q)
       const bookPromise: Promise<Book[]> = new Promise((resolve, reject) => {
@@ -28,25 +28,3 @@ export default (query: any): [boolean, Book[]] => {
   useEffect(listBooks(query), [query]);
   return [loading, books];
 };
-
-
-  // const [query, setQuery] = useState("");
-
-
-  // const listBooks = ((query: string) => {
-  //   const req = new ListBooksRequest();
-  //   req.setFilter(query)
-  //   const meta = {'authorization': 'xxxxx'}
-  //   bookService.listBooks(req, meta, (err: any, resp: ListBooksResponse) => {
-  //     if (err) {
-  //       console.log(err);
-  //     } else {
-  //       console.log(resp.getBooksList());
-  //       setBooks(resp.getBooksList());
-  //     }
-  //   });
-  // });
-
-  // useEffect(() => {
-  //   listBooks(query);
-  // }, [query]);

--- a/rentalsvc/Dockerfile
+++ b/rentalsvc/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.11-alpine
 
+RUN apk add --no-cache --virtual build-base
+
 COPY . /go/src/github.com/Buzzvil/stella/rentalsvc
 
 RUN go build -o /go/bin/rentalsvc github.com/Buzzvil/stella/rentalsvc/cmd/rentalsvc


### PR DESCRIPTION
* Slack auth redirect 이후 `auth-token` 쿠키에 jwt 토큰 세팅
* envoy authz filter `Check` 메소드에서 `auto-token` 쿠키값 이용하도록 변경
* booksvc의 `BookLister`에서 `BookServiceClient` 사용해 grpc-web 및 authz filter 사용여부 확인
